### PR TITLE
PDO & Docker

### DIFF
--- a/PREREQUISITES.md
+++ b/PREREQUISITES.md
@@ -103,7 +103,7 @@ If the above succeeds, define/extend the `PKG_CONFIG_PATH` environment variable 
 ```
 export PKG_CONFIG_PATH="$(pwd)/install/lib/pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
 ```
-You might also want to extend `LD_LIBRARY_PATH`, e.g., as
+If you installed in a standard location (e.g., default /usr/local/lib) you might have to call 'ldconfig'; if in a non-standard location you might have to extend LD_LIBRARY_PATH, e.g., as
 ```
 export LD_LIBRARY_PATH="$(pwd)/install/lib/${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
 ```

--- a/docker/Dockerfile.pdo-dev
+++ b/docker/Dockerfile.pdo-dev
@@ -1,0 +1,149 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+# Description:
+#   Builds the environment needed to build Private Data Objects.
+#
+#  Configuration (build) paramaters
+#  - proxy configuration: https_proxy http_proxy ftp_proxy
+#  - sgx mode: 
+#
+# Build:
+#   $ docker build docker -f docker/Dockerfile.pdo-dev -t pdo-dev
+#   if behind a proxy, you might want to add also below options
+#   --build-arg https_proxy=$https_proxy --build-arg http_proxy=$http_proxy --build-arg ftp_proxy=$ftp_proxy
+#   if you want to build with different version than 16.04/xenial, add a build arg UBUNTU_VERSION, e.g., for 18.04 do --build-arg UBUNTU_VERSION=bionic
+#
+# Run:
+#   $ cd PrivateDataObjects
+#   $ docker run -v $(pwd):/project/pdo/src pdo-dev -it /bin/bash
+#   (to run with SGX HW, add options '--device=/dev/isgx -v /var/run/aesmd:/var/run/aesmd ')
+#   then you can build system as "usual" (e.g., make -C /project/pdo/src/__tools__/build/ DSTDIR=/project/pdo/build )
+#   etc etc 
+
+ARG UBUNTU_VERSION=xenial
+# 16.04 -> xenial, 17.10 -> artful, 18.04 -> bionic
+
+FROM ubuntu:${UBUNTU_VERSION}
+
+ARG UBUNTU_VERSION=xenial
+# for bizare docker reason, we have to redefine it here ...
+
+# Add sawtooth repo
+RUN apt-get update \
+ && apt-get install -y -q\
+    build-essential \
+    ca-certificates \
+    cmake \
+    git \
+    make \
+    pkg-config \
+    cmake \
+    libprotobuf-dev \
+    python3-dev \
+    python3-virtualenv \
+    virtualenv \
+    swig  \
+    wget \
+    unzip \
+    tar \
+ && if [ "$UBUNTU_VERSION" = "bionic" ] || [ "$UBUNTU_VERSION" = "artful" ]; then \
+        apt-get install -y -q libsecp256k1-dev; \
+    fi \
+ && apt-get -y -q upgrade \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+# Install Tinyscheme
+RUN mkdir -p /opt/tinyscheme
+WORKDIR /opt/tinyscheme
+RUN wget https://downloads.sourceforge.net/project/tinyscheme/tinyscheme/tinyscheme-1.41/tinyscheme-1.41.zip \
+ && unzip tinyscheme-1.41.zip \
+ && rm tinyscheme-1.41.zip  \
+ && cd tinyscheme-1.41  \
+ && make \
+ && echo "TINY_SCHEME_SRC=$(pwd)" >> /etc/environment
+
+# Install SGX SDK
+RUN mkdir -p /opt/intel
+WORKDIR /opt/intel
+RUN wget https://download.01.org/intel-sgx/linux-2.1.2/ubuntu64-server/sgx_linux_x64_sdk_2.1.102.43402.bin \
+ && chmod +x sgx_linux_x64_sdk_2.1.102.43402.bin \
+ && echo "yes" | ./sgx_linux_x64_sdk_2.1.102.43402.bin \
+ && rm sgx_linux_x64_sdk_2.1.102.43402.bin \
+ && echo ". /opt/intel/sgxsdk/environment" >> /etc/environment
+
+# ("Untrusted") OpenSSL
+WORKDIR /tmp
+RUN wget https://www.openssl.org/source/openssl-1.1.0h.tar.gz \
+ && tar -zxvf openssl-1.1.0h.tar.gz \
+ && cd openssl-1.1.0h/ \
+ && ./config \
+ && THREADS=8 \
+ && make -j$THREADS \
+ && make test \
+ && make install -j$THREADS \
+ && ldconfig \
+ && cd .. \
+ && rm -rf openssl-1.1.0h
+# Note: we do _not_ delete openssl-1.1.0h.tar.gz as we re-use it below ..
+
+
+# ("trusted") SGX OpenSSL
+# Note: Ideally we would below patch only on non-SGX machines so the sgxssl tests 
+# would work with real hw. Alas, it doesn't seem possible to pass devices to 
+# docker build, not docker run, so can't do some conditionals ..
+WORKDIR /tmp
+COPY sgxssl.patch .
+RUN git clone https://github.com/intel/intel-sgx-ssl.git  \
+ && . /opt/intel/sgxsdk/environment \
+ && (cd intel-sgx-ssl/openssl_source; mv /tmp/openssl-1.1.0h.tar.gz . ) \
+ && (cd intel-sgx-ssl; git apply --ignore-whitespace ../sgxssl.patch) \
+ && (cd intel-sgx-ssl/Linux; ./build_sgxssl.sh ) \
+ && mkdir -p /opt/intel/sgxssl \
+ && (cd /opt/intel/sgxssl; tar xzf /tmp/intel-sgx-ssl/Linux/sgxssl.*.99999.tar.gz ) \
+ && rm -rf /tmp/intel-sgx-ssl /tmp/sgxssl.patch \
+ && echo "SGX_SSL=/opt/intel/sgxssl" >> /etc/environment
+
+# environment setup
+# - make proxy persistent ..
+# - make sure /etc/environment is always included for bash. Note this still doesn't make these environment variables visible to all in docker!!
+RUN \
+    mkdir -p /project/pdo \
+ && echo "CONTRACTHOME=/project/pdo/build/opt/pdo" >> /etc/environment \
+ && echo "POET_ENCLAVE_PEM=/project/pdo/enclave.pem" >> /etc/environment \
+ && openssl genrsa -3 3072 > /project/pdo/enclave.pem \
+ && if [ ! -z "$http_proxy"  ]; then \
+	echo 'Acquire::http::Proxy "'$http_proxy'";' >> /etc/apt/apt.conf.d/00proxy; \
+        echo "http_proxy=$http_proxy" >> /etc/wgetrc; \
+        echo "http_proxy=$http_proxy" >> /etc/environment; \
+        echo "HTTP_PROXY=$(echo $http_proxy | sed 's,[a-zA-Z]*://,,')" >> /etc/environment; \
+    fi \
+ && if [ ! -z "$ftp_proxy"  ];  then \
+	echo 'Acquire::ftp::Proxy "'$ftp_proxy'";' >> /etc/apt/apt.conf.d/00proxy; \
+        echo "ftp_proxy=$ftp_proxy" >> /etc/wgetrc; \
+        echo "ftp_proxy=$ftp_proxy" >> /etc/environment; \
+    fi \
+ && if [ ! -z "$https_proxy" ]; then \
+	echo 'Acquire::https::Proxy "'$https_proxy'";' >> /etc/apt/apt.conf.d/00proxy; \
+    	echo "https_proxy=$https_proxy" >> /etc/wgetrc; \
+        echo "https_proxy=$https_proxy" >> /etc/environment; \
+        echo "HTTPS_PROXY=$(echo $https_proxy | sed 's,[a-zA-Z]*://,,')" >> /etc/environment; \
+    fi \
+ && sed -i '1s;^;source /etc/environment\nexport $(grep -v "^. " /etc/environment| cut -d= -f1)\n;' /root/.bashrc 
+
+WORKDIR /project/pdo/
+
+#ENTRYPOINT ["make -C /project/pdo/src/__tools__/build/ DSTDIR=/project/pdo/build "]

--- a/docker/sgxssl.patch
+++ b/docker/sgxssl.patch
@@ -1,0 +1,25 @@
+diff --git a/Linux/build_sgxssl.sh b/Linux/build_sgxssl.sh
+index 47de809..88437e1 100755
+--- a/Linux/build_sgxssl.sh
++++ b/Linux/build_sgxssl.sh
+@@ -171,7 +171,9 @@ cd $SGXSSL_ROOT/sgx || clean_and_ret 1
+
+ make OS_ID=$OS_ID SGXSDK_INT_VERSION=$SGXSDK_INT_VERSION $LINUX_BUILD_FLAG || clean_and_ret 1 # will also copy the resulting files to package
+ if [[ $1 != "linux-sgx" && $2 != "linux-sgx" ]] ; then
+-       ./test_app/TestApp || clean_and_ret 1 # verify everything is working ok
++       # MST: workaround to build on sim only,see issue #10 https://github.com/intel/intel-sgx-ssl/issues/10
++       echo "skip running in prerelease mode"
++#      ./test_app/TestApp || clean_and_ret 1 # verify everything is working ok
+ fi
+ make clean || clean_and_ret 1
+
+@@ -210,7 +212,8 @@ make clean || clean_and_ret 1
+
+ make OS_ID=$OS_ID SGXSDK_INT_VERSION=$SGXSDK_INT_VERSION DEBUG=1 $LINUX_BUILD_FLAG || clean_and_ret 1 # will also copy the resulting files to package
+ if [[ $1 != "linux-sgx" && $2 != "linux-sgx" ]] ; then
+-       ./test_app/TestApp || clean_and_ret 1 # verify everything is working ok
++       echo "skip running in prerelease mode"
++       # ./test_app/TestApp || clean_and_ret 1 # verify everything is working ok
+ fi
+ make clean || clean_and_ret 1
+


### PR DESCRIPTION
A first step towards building and running PDOs inside docker. Right now it just sets up pre-requisites to be able to run 'make -C tools/build' and does so for configurable ubuntu version (see header in docker/Dockerfile.pdo-dev).  Can be used for quickly doing tests on clean environments on different ubuntu versions. Potentially could serve as basis for some continuous integration tests? Eventually it might evolve into docker images also for running the pdo services and a potential integration with sawtooth's docker-compose files ...

Primarily added pull request to get initial feedback/thoughts on changes/where you would like to see it heading (if considered useful at all). However, it should already work if you want a quick clean dev environment....